### PR TITLE
Simplify mouse sensitivity math.

### DIFF
--- a/src/main/java/net/wurstclient/zoom/WiZoom.java
+++ b/src/main/java/net/wurstclient/zoom/WiZoom.java
@@ -67,10 +67,9 @@ public enum WiZoom
 			defaultMouseSensitivity = gameOptions.mouseSensitivity;
 			
 		// Adjust mouse sensitivity in relation to zoom level.
-		// (fov / currentLevel) / fov is a value between 0.02 (50x zoom)
+		// (1 / currentLevel) is a value between 0.02 (50x zoom)
 		// and 1 (no zoom).
-		gameOptions.mouseSensitivity =
-			defaultMouseSensitivity * (fov / currentLevel / fov);
+		gameOptions.mouseSensitivity = defaultMouseSensitivity / currentLevel;
 		
 		return fov / currentLevel;
 	}


### PR DESCRIPTION
This equation should be equivalent to the old one, but with less floating point operations and so it should be faster/more precise/less error prone.