### PR TITLE
Fix Incompatibility with Canvas

### DIFF
--- a/src/main/java/net/wurstclient/zoom/mixin/GameRendererMixin.java
+++ b/src/main/java/net/wurstclient/zoom/mixin/GameRendererMixin.java
@@ -29,8 +29,8 @@ public class GameRendererMixin
 	private void onGetFov(Camera camera, float tickDelta, boolean changingFov,
 		CallbackInfoReturnable<Double> cir)
 	{
-		cir.setReturnValue(
-			WiZoom.INSTANCE.changeFovBasedOnZoom(cir.getReturnValueD()));
+		double fov = WiZoom.INSTANCE.changeFovBasedOnZoom(cir.getReturnValueD());
+		cir.setReturnValue(fov);
 	}
 	
 	@Shadow


### PR DESCRIPTION
This fixes https://github.com/vram-guild/canvas/issues/390

I can't explain how this fix works. It just.. does. I tested it about 6 times. Yep, fixed.

Ok, some technical detail: without this fix, Canvas's codepath that is part of its on-return getFov() mixin isn't being executed. My best guess is that the function returns early.

Screenshots

BEFORE
![image](https://user-images.githubusercontent.com/8444172/181917144-96031f77-c215-4d48-b06d-2dad08b42779.png)

AFTER
![image](https://user-images.githubusercontent.com/8444172/181917146-dd5eb07b-5bef-40c3-b0d1-d1094d015a9b.png)
